### PR TITLE
Improve image size

### DIFF
--- a/resources/views/picker.blade.php
+++ b/resources/views/picker.blade.php
@@ -5,7 +5,7 @@
     $icons = $getIcons();
     $images = $getImages();
     $imageOnly = $getImageOnly();
-    $imageSize = $getImageSize() ?: 50;
+    $imageSize = $getImageSize();
     $checkedColor = Color::Green[500];
 @endphp
 
@@ -17,8 +17,8 @@
     <div
         {{ $attributes->merge($getExtraAttributes())->class(['ic-fo-picker']) }}
     >
-        <div 
-            x-data="{ 
+        <div
+            x-data="{
                 state: $wire.{{ $applyStateBindingModifiers('entangle(\'' . $getStatePath() . '\')') }},
                 setState: function(value) {
                     if(this.state == value){
@@ -26,7 +26,7 @@
                         return
                     }
                     this.state = value;
-                    
+
                     {{-- this.$refs.input.value = value --}}
                 }
             }"
@@ -39,7 +39,7 @@
             >
             <!-- Interact with the `state` property in Alpine.js -->
             @foreach($options as $value => $label)
-                <button 
+                <button
                     type="button"
                     x-bind:class="
                         state == '{{ $value }}'
@@ -47,9 +47,9 @@
                             : 'px-2 py-1 rounded text-gray-900 shadow relative dark:bg-gray-700'
                         "
                     x-on:click="setState('{{ $value }}')"
-                > 
+                >
                     @if(filled($images))
-                        <img src="{{ $images[$value] }}" alt="{{ $label }}" style="width:{{ $imageSize }}px; height:{{ $imageSize }}px;">
+                        <img src="{{ $images[$value] }}" alt="{{ $label }}" style="width:{{ $imageSize[0] }}; height:{{ $imageSize[1] }};">
                     @endif
 
                     <div class="flex items-center text-center">
@@ -71,7 +71,7 @@
                             />
                         </span>
                     </div>
-                      
+
                 </button>
             @endforeach
 

--- a/src/Forms/Components/Picker.php
+++ b/src/Forms/Components/Picker.php
@@ -59,9 +59,29 @@ class Picker extends Field
         return $this;
     }
 
-    public function getImageSize(): int
+    public function getImageSize(): array
     {
-        return (int)$this->evaluate($this->imageSize);
+        $size = $this->evaluate($this->imageSize);
+
+        if (is_int($size)) {
+            return ["{$size}px", null];
+        }
+
+        if (is_string($size)) {
+            return [$size, null];
+        }
+
+        if (is_array($size)) {
+            $width = $size[0] ?? null;
+            $height = $size[1] ?? null;
+
+            $width = is_int($width) ? "{$width}px" : (string) $width;
+            $height = is_int($height) ? "{$height}px" : (string) $height;
+
+            return [$width, $height];
+        }
+
+        return ['auto', null];
     }
 
     public function imageOnly(bool | Closure $condition = true){


### PR DESCRIPTION
The method now defaults height to "100%" when not provided, ensuring responsive behavior. It supports various input types (integers, strings, arrays) and normalizes them by adding "px" to integer values. This enhances flexibility, simplifies input handling, and ensures consistent, reliable output for layout purposes.