### PR TITLE
Feature: Background color control

### DIFF
--- a/resources/views/picker.blade.php
+++ b/resources/views/picker.blade.php
@@ -8,6 +8,8 @@
     $imageSize = $getImageSize() ?: 50;
     $checkedColor = Color::Green[500];
     $multiple = $getMultiple();
+    $bgColor = $getBackgroundColor();
+    $activeBgColor = $getActiveBackgroundColor();
 @endphp
 
 <x-dynamic-component
@@ -62,10 +64,11 @@
                 <button
                     type="button"
                     x-bind:class="@if($multiple) state.includes('{{ $value }}') @else state == '{{ $value }}' @endif
-                            ? 'px-2 py-1 rounded shadow bg-primary-500 text-white relative'
-                            : 'px-2 py-1 rounded text-gray-900 shadow relative dark:bg-gray-700'"
+                            ? 'px-2 py-1 rounded shadow {{ $activeBgColor }} text-white relative'
+                            : 'px-2 py-1 rounded text-gray-900 shadow relative {{ $bgColor }}'"
                     x-on:click="setState('{{ $value }}')"
                 >
+
                     @if(filled($images))
                         <img src="{{ $images[$value] }}" alt="{{ $label }}"
                              style="width:{{ $imageSize }}px; height:{{ $imageSize }}px;" draggable="false">

--- a/resources/views/picker.blade.php
+++ b/resources/views/picker.blade.php
@@ -1,5 +1,6 @@
 @php
     use Filament\Support\Colors\Color;
+    use Filament\Support\Enums\Alignment;
 
     $options = $getOptions();
     $icons = $getIcons();
@@ -8,6 +9,11 @@
     $imageSize = $getImageSize() ?: 50;
     $checkedColor = Color::Green[500];
     $multiple = $getMultiple();
+    $alignment = $getAlignment();
+
+    if (! $alignment instanceof Alignment) {
+        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+    }
 @endphp
 
 <x-dynamic-component
@@ -49,6 +55,19 @@
                         }
                     }"
             @endif
+            @class([
+                'flex flex-wrap gap-2',
+                match ($alignment) {
+                    Alignment::Start => 'justify-start',
+                    Alignment::Center => 'justify-center',
+                    Alignment::End => 'justify-end',
+                    Alignment::Left => 'justify-start',
+                    Alignment::Right => 'justify-end',
+                    Alignment::Between => 'justify-between',
+                    Alignment::Justify => 'justify-around',
+                    default => $alignment,
+                }
+            ])
             class="flex flex-wrap gap-2 justify-around"
         >
             <input

--- a/src/Forms/Components/Picker.php
+++ b/src/Forms/Components/Picker.php
@@ -24,10 +24,37 @@ class Picker extends Field
 
     protected bool|Closure $multiple = false;
 
+    protected string|Closure $backgroundColor = 'bg-white dark:bg-gray-800';
+
+    protected string|Closure $activeBackgroundColor = 'bg-primary-500';
+
     protected function setUp(): void
     {
         parent::setUp();
+    }
 
+    public function backgroundColor(string | Closure $color): static
+    {
+        $this->backgroundColor = $color;
+
+        return $this;
+    }
+
+    public function activeBackgroundColor(string | Closure $color): static
+    {
+        $this->activeBackgroundColor = $color;
+
+        return $this;
+    }
+
+    public function getBackgroundColor(): string
+    {
+        return (string)$this->evaluate($this->backgroundColor);
+    }
+
+    public function getActiveBackgroundColor(): string
+    {
+        return (string)$this->evaluate($this->activeBackgroundColor);
     }
 
     public function icons(array | Closure $icons): static

--- a/src/Forms/Components/Picker.php
+++ b/src/Forms/Components/Picker.php
@@ -5,12 +5,14 @@ namespace Icetalker\FilamentPicker\Forms\Components;
 use Closure;
 use Filament\Forms\Components\Concerns\HasOptions;
 use Filament\Forms\Components\Field;
+use Filament\Support\Concerns\HasAlignment;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
 
 class Picker extends Field
 {
     use HasOptions;
     use HasExtraAlpineAttributes;
+    use HasAlignment;
 
     protected string $view = 'filament-picker::picker';
 


### PR DESCRIPTION
This PR adds two new methods:

```php
->backgroundColor('bg-white dark:bg-gray-800')
->activeBackgroundColor('bg-gray-400')
```

thanks to which you can control the background colors. 
This is especially useful if you use images with transparent backgrounds in Picker.