### PR TITLE
Fix typo of capital S in heroicon

### DIFF
--- a/resources/views/picker.blade.php
+++ b/resources/views/picker.blade.php
@@ -107,7 +107,7 @@
                          x-show="state.includes('{{ $value }}')">
                             <span style="color:{{ $checkedColor }}">
                                 <x-filament::icon
-                                    icon="heroicon-S-check-circle"
+                                    icon="heroicon-s-check-circle"
                                 />
                             </span>
                     </div>


### PR DESCRIPTION
While it does run fine on most environments, some others (like Laravel Cloud and probably most linux distros) throw error as heroicon-S-check-circle does not exist, if the filesystem is case sensitive