### PR TITLE
Chore: Remove illuminate packages from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,6 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "filament/forms": "^4.0|^5.0",
         "filament/support": "^4.0|^5.0"
     },
     "autoload": {


### PR DESCRIPTION
Removes illuminate packages from composer.json. This allows to check laravel version by Filament, not this package.
